### PR TITLE
Use one-up IDs instead of "1".

### DIFF
--- a/src/actions/ContentRepositoryActions.js
+++ b/src/actions/ContentRepositoryActions.js
@@ -3,7 +3,11 @@ import DockerUtil from '../utils/DockerUtil';
 
 class ContentRepositoryActions {
 
-  launch (id, controlRepositoryLocation, contentRepositoryPath) {
+  launch (controlRepositoryLocation, contentRepositoryPath) {
+    let lastID = parseInt(sessionStorage.getItem('content-repository-id') || '0');
+    let id = lastID + 1;
+    sessionStorage.setItem('content-repository-id', id.toString())
+
     DockerUtil.launchServicePod(id, controlRepositoryLocation);
     this.dispatch({id, controlRepositoryLocation, contentRepositoryPath});
   }

--- a/src/components/EditContentRepository.react.js
+++ b/src/components/EditContentRepository.react.js
@@ -19,7 +19,7 @@ var EditContentRepository = React.createClass({
   },
 
   handleCreate: function () {
-    ContentRepositoryActions.launch("1", this.controlRepositoryLocation, this.contentRepositoryPath);
+    ContentRepositoryActions.launch(this.controlRepositoryLocation, this.contentRepositoryPath);
 
     this.transitionTo("repositoryList");
   },

--- a/src/stores/ContentRepositoryStore.js
+++ b/src/stores/ContentRepositoryStore.js
@@ -5,11 +5,12 @@ import DockerUtil from '../utils/DockerUtil';
 
 class ContentRepository {
 
-  constructor (id, controlRepositoryLocation, contentRepositoryPath) {
+  constructor (id, controlRepositoryLocation, contentRepositoryPath, preparer) {
     this.id = id;
     this.controlRepositoryLocation = controlRepositoryLocation;
     this.contentRepositoryPath = contentRepositoryPath;
     this.state = "launching";
+    this.preparer = preparer;
 
     this.contentContainer = null;
     this.presenterContainer = null;
@@ -19,15 +20,23 @@ class ContentRepository {
     return path.basename(this.contentRepositoryPath);
   }
 
-  publicURL() {
-    if (!this.presenterContainer) {
+  _containerURL(container) {
+    if (!container) {
       return "";
     }
 
     let host = DockerUtil.host;
-    let port = this.presenterContainer.NetworkSettings.Ports['8080/tcp'][0].HostPort;
+    let port = container.NetworkSettings.Ports['8080/tcp'][0].HostPort;
 
     return "http://" + host + ":" + port + "/";
+  }
+
+  publicURL() {
+    return this._containerURL(this.presenterContainer);
+  }
+
+  contentURL() {
+    return this._containerURL(this.contentContainer);
   }
 
 }
@@ -40,7 +49,7 @@ class ContentRepositoryStore {
   }
 
   onLaunch({id, controlRepositoryLocation, contentRepositoryPath}) {
-    this.repositories[id] = new ContentRepository(id, controlRepositoryLocation, contentRepositoryPath);
+    this.repositories[id] = new ContentRepository(id, controlRepositoryLocation, contentRepositoryPath, "sphinx");
   }
 
   onPodLaunched({id, contentContainer, presenterContainer}) {


### PR DESCRIPTION
This lets you watch multiple content repositories at once!
