### PR TITLE
Preparer

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,8 @@
     "request-progress": "^0.3.1",
     "rimraf": "^2.3.2",
     "underscore": "^1.8.3",
-    "validator": "^3.39.0"
+    "validator": "^3.39.0",
+    "watchr": "^2.4.13"
   },
   "devDependencies": {
     "babel": "^5.1.10",

--- a/src/actions/ContentRepositoryActions.js
+++ b/src/actions/ContentRepositoryActions.js
@@ -24,6 +24,10 @@ class ContentRepositoryActions {
     this.dispatch({repo, container});
   }
 
+  containerCompleted ({container}) {
+    this.dispatch({container});
+  }
+
   error ({repo, error}) {
     this.dispatch({repo, error});
   }

--- a/src/actions/ContentRepositoryActions.js
+++ b/src/actions/ContentRepositoryActions.js
@@ -12,8 +12,17 @@ class ContentRepositoryActions {
     this.dispatch({id, controlRepositoryLocation, contentRepositoryPath});
   }
 
+  prepare (id, preparer, contentURL, contentRepositoryPath) {
+    DockerUtil.launchPreparer(id, preparer, contentURL, contentRepositoryPath);
+    this.dispatch({id});
+  }
+
   podLaunched ({id, contentContainer, presenterContainer}) {
     this.dispatch({id, contentContainer, presenterContainer});
+  }
+
+  preparerLaunched ({id, container}) {
+    this.dispatch({id, container});
   }
 
   error ({id, error}) {

--- a/src/actions/ContentRepositoryActions.js
+++ b/src/actions/ContentRepositoryActions.js
@@ -1,32 +1,31 @@
 import alt from '../alt';
 import DockerUtil from '../utils/DockerUtil';
+import {ContentRepository} from '../utils/ContentRepositoryUtil';
 
 class ContentRepositoryActions {
 
-  launch (controlRepositoryLocation, contentRepositoryPath) {
-    let lastID = parseInt(sessionStorage.getItem('content-repository-id') || '0');
-    let id = lastID + 1;
-    sessionStorage.setItem('content-repository-id', id.toString())
+  launch (controlRepositoryLocation, contentRepositoryPath, preparer) {
+    let repo = new ContentRepository(controlRepositoryLocation, contentRepositoryPath, preparer);
+    this.dispatch({repo});
 
-    DockerUtil.launchServicePod(id, controlRepositoryLocation);
-    this.dispatch({id, controlRepositoryLocation, contentRepositoryPath});
+    DockerUtil.launchServicePod(repo);
   }
 
-  prepare (id, preparer, contentURL, contentRepositoryPath) {
-    DockerUtil.launchPreparer(id, preparer, contentURL, contentRepositoryPath);
-    this.dispatch({id});
+  prepare (repo) {
+    DockerUtil.launchPreparer(repo);
+    this.dispatch({repo});
   }
 
-  podLaunched ({id, contentContainer, presenterContainer}) {
-    this.dispatch({id, contentContainer, presenterContainer});
+  podLaunched ({repo, contentContainer, presenterContainer}) {
+    this.dispatch({repo, contentContainer, presenterContainer});
   }
 
-  preparerLaunched ({id, container}) {
-    this.dispatch({id, container});
+  preparerLaunched ({repo, container}) {
+    this.dispatch({repo, container});
   }
 
-  error ({id, error}) {
-    this.dispatch({id, error});
+  error ({repo, error}) {
+    this.dispatch({repo, error});
   }
 
 }

--- a/src/components/ContentRepositoryCard.react.js
+++ b/src/components/ContentRepositoryCard.react.js
@@ -13,6 +13,7 @@ var ContentRepositoryCard = React.createClass({
 
   render: function () {
     let repo = this.props.repository;
+    let disableSubmit = ! repo.canSubmit();
 
     return (
       <div className="content-repository-card">
@@ -20,8 +21,8 @@ var ContentRepositoryCard = React.createClass({
         <div className="details">
           <p className="content-path">{repo.contentRepositoryPath}</p>
           <p className="content-preview">
+            <a className="btn btn-info btn-sm submit" onClick={this.handleSubmit} disabled={disableSubmit}>submit</a>
             <span className="state">{repo.state}</span>
-            <a className="btn btn-info btn-sm" onClick={this.handleSubmit}>submit</a>
             <a className="preview" onClick={this.handlePreview}>{repo.publicURL()}</a>
           </p>
           <p className="error">

--- a/src/components/ContentRepositoryCard.react.js
+++ b/src/components/ContentRepositoryCard.react.js
@@ -1,9 +1,14 @@
 import React from 'react/addons';
 import shell from 'shell';
+import ContentRepositoryActions from '../actions/ContentRepositoryActions';
 
 var ContentRepositoryCard = React.createClass({
   handlePreview: function () {
     shell.openExternal(this.props.repository.publicURL());
+  },
+
+  handleSubmit: function () {
+    ContentRepositoryActions.prepare(this.props.repository);
   },
 
   render: function () {
@@ -16,6 +21,7 @@ var ContentRepositoryCard = React.createClass({
           <p className="content-path">{repo.contentRepositoryPath}</p>
           <p className="content-preview">
             <span className="state">{repo.state}</span>
+            <a className="btn btn-info btn-sm" onClick={this.handleSubmit}>submit</a>
             <a className="preview" onClick={this.handlePreview}>{repo.publicURL()}</a>
           </p>
           <p className="error">

--- a/src/components/EditContentRepository.react.js
+++ b/src/components/EditContentRepository.react.js
@@ -6,12 +6,24 @@ import ContentRepositoryActions from '../actions/ContentRepositoryActions';
 var EditContentRepository = React.createClass({
   mixins: [Router.Navigation],
 
+  getInitialState: function () {
+    return {
+      contentRepositoryPath: "/Users/ashl6947/writing/docs-quickstart",
+      controlRepositoryLocation: "/Users/ashl6947/writing/nexus-control",
+      preparer: "sphinx"
+    };
+  },
+
   handleRepositoryPathChange: function (e) {
-    this.contentRepositoryPath = e.target.value;
+    this.setState({contentRepositoryPath: e.target.value});
   },
 
   handleControlRepositoryChange: function (e) {
-    this.controlRepositoryLocation = e.target.value;
+    this.setState({controlRepositoryLocation: e.target.value});
+  },
+
+  handlePreparerChange: function (e) {
+    this.setState({preparer: e.target.value});
   },
 
   handleCancel: function () {
@@ -19,7 +31,8 @@ var EditContentRepository = React.createClass({
   },
 
   handleCreate: function () {
-    ContentRepositoryActions.launch(this.controlRepositoryLocation, this.contentRepositoryPath);
+    ContentRepositoryActions.launch(this.state.controlRepositoryLocation,
+      this.state.contentRepositoryPath, this.state.preparer);
 
     this.transitionTo("repositoryList");
   },
@@ -33,14 +46,22 @@ var EditContentRepository = React.createClass({
           <div className="repository-path">
             <h3>Repository Path</h3>
             <p className="explanation">Filesystem path to the content repository.</p>
-            <input id="input-repository-path" type="text" className="line" placeholder="/some/path" onChange={this.handleRepositoryPathChange}></input>
+            <input id="input-repository-path" type="text" className="line" value={this.state.contentRepositoryPath} placeholder="/some/path" onChange={this.handleRepositoryPathChange}></input>
           </div>
           <div className="control-repository">
             <h3>Control Repository Location</h3>
             <p className="explanation">
               Location of the control repository. May be either a git URL or a local filesystem path.
             </p>
-            <input id="control-repository" type="text" className="line" placeholder="https://github.com/deconst/deconst-docs-control.git" onChange={this.handleControlRepositoryChange}></input>
+            <input id="control-repository" type="text" className="line" value={this.state.controlRepositoryLocation} placeholder="https://github.com/deconst/deconst-docs-control.git" onChange={this.handleControlRepositoryChange}></input>
+          </div>
+          <div className="preparer">
+            <h3>Preparer</h3>
+            <p className="explanation">Preparer to use to prepare the content.</p>
+            <select id="preparer" value={this.state.preparer} onChange={this.handlePreparerChange}>
+              <option value="sphinx">Sphinx</option>
+              <option value="jekyll">Jekyll</option>
+            </select>
           </div>
           <div className="controls">
             <button className="btn btn-large btn-default" onClick={this.handleCancel}>Cancel</button>

--- a/src/stores/ContentRepositoryStore.js
+++ b/src/stores/ContentRepositoryStore.js
@@ -23,6 +23,8 @@ class ContentRepositoryStore {
     r.state = "ready";
     r.contentContainer = contentContainer;
     r.presenterContainer = presenterContainer;
+
+    DockerUtil.launchPreparer(r);
   }
 
   onPrepare({repo}) {

--- a/src/stores/ContentRepositoryStore.js
+++ b/src/stores/ContentRepositoryStore.js
@@ -55,18 +55,36 @@ class ContentRepositoryStore {
   onPodLaunched({id, contentContainer, presenterContainer}) {
     let repo = this.repositories[id];
     if (!repo) {
-      return ;
+      return;
     }
 
-    repo.state = "ready"
+    repo.state = "ready";
     repo.contentContainer = contentContainer;
     repo.presenterContainer = presenterContainer;
+  }
+
+  onPrepare({id}) {
+    let repo = this.repositories[id];
+    if (!repo) {
+      return;
+    }
+
+    repo.state = "launching preparer";
+  }
+
+  onPreparerLaunched({id}) {
+    let repo = this.repositories[id];
+    if (!repo) {
+      return;
+    }
+
+    repo.state = "submitting";
   }
 
   onError({id, error}) {
     let repo = this.repositories[id];
     if (!repo) {
-      return ;
+      return;
     }
 
     repo.state = "error";

--- a/src/stores/ContentRepositoryStore.js
+++ b/src/stores/ContentRepositoryStore.js
@@ -3,44 +3,6 @@ import alt from '../alt';
 import ContentRepositoryActions from '../actions/ContentRepositoryActions';
 import DockerUtil from '../utils/DockerUtil';
 
-class ContentRepository {
-
-  constructor (id, controlRepositoryLocation, contentRepositoryPath, preparer) {
-    this.id = id;
-    this.controlRepositoryLocation = controlRepositoryLocation;
-    this.contentRepositoryPath = contentRepositoryPath;
-    this.state = "launching";
-    this.preparer = preparer;
-
-    this.contentContainer = null;
-    this.presenterContainer = null;
-  }
-
-  name () {
-    return path.basename(this.contentRepositoryPath);
-  }
-
-  _containerURL(container) {
-    if (!container) {
-      return "";
-    }
-
-    let host = DockerUtil.host;
-    let port = container.NetworkSettings.Ports['8080/tcp'][0].HostPort;
-
-    return "http://" + host + ":" + port + "/";
-  }
-
-  publicURL() {
-    return this._containerURL(this.presenterContainer);
-  }
-
-  contentURL() {
-    return this._containerURL(this.contentContainer);
-  }
-
-}
-
 class ContentRepositoryStore {
 
   constructor() {
@@ -48,47 +10,47 @@ class ContentRepositoryStore {
     this.repositories = {};
   }
 
-  onLaunch({id, controlRepositoryLocation, contentRepositoryPath}) {
-    this.repositories[id] = new ContentRepository(id, controlRepositoryLocation, contentRepositoryPath, "sphinx");
+  onLaunch({repo}) {
+    this.repositories[repo.id] = repo;
   }
 
-  onPodLaunched({id, contentContainer, presenterContainer}) {
-    let repo = this.repositories[id];
-    if (!repo) {
+  onPodLaunched({repo, contentContainer, presenterContainer}) {
+    let r = this.repositories[repo.id];
+    if (!r) {
       return;
     }
 
-    repo.state = "ready";
-    repo.contentContainer = contentContainer;
-    repo.presenterContainer = presenterContainer;
+    r.state = "ready";
+    r.contentContainer = contentContainer;
+    r.presenterContainer = presenterContainer;
   }
 
-  onPrepare({id}) {
-    let repo = this.repositories[id];
-    if (!repo) {
+  onPrepare({repo}) {
+    let r = this.repositories[repo.id];
+    if (!r) {
       return;
     }
 
-    repo.state = "launching preparer";
+    r.state = "launching preparer";
   }
 
-  onPreparerLaunched({id}) {
-    let repo = this.repositories[id];
-    if (!repo) {
+  onPreparerLaunched({repo}) {
+    let r = this.repositories[repo.id];
+    if (!r) {
       return;
     }
 
-    repo.state = "submitting";
+    r.state = "submitting";
   }
 
-  onError({id, error}) {
-    let repo = this.repositories[id];
-    if (!repo) {
+  onError({repo, error}) {
+    let r = this.repositories[repo.id];
+    if (!r) {
       return;
     }
 
-    repo.state = "error";
-    repo.error = error;
+    r.state = "error";
+    r.error = error;
   }
 
 }

--- a/src/utils/ContentRepositoryUtil.js
+++ b/src/utils/ContentRepositoryUtil.js
@@ -1,0 +1,44 @@
+import path from 'path';
+import DockerUtil from './DockerUtil';
+
+export class ContentRepository {
+
+  constructor (controlRepositoryLocation, contentRepositoryPath, preparer) {
+    let lastID = parseInt(sessionStorage.getItem('content-repository-id') || '0');
+    let id = lastID + 1;
+    sessionStorage.setItem('content-repository-id', id.toString())
+
+    this.id = id;
+    this.controlRepositoryLocation = controlRepositoryLocation;
+    this.contentRepositoryPath = contentRepositoryPath;
+    this.state = "launching";
+    this.preparer = preparer;
+
+    this.contentContainer = null;
+    this.presenterContainer = null;
+  }
+
+  name () {
+    return path.basename(this.contentRepositoryPath);
+  }
+
+  _containerURL(container) {
+    if (!container) {
+      return "";
+    }
+
+    let host = DockerUtil.host;
+    let port = container.NetworkSettings.Ports['8080/tcp'][0].HostPort;
+
+    return "http://" + host + ":" + port + "/";
+  }
+
+  publicURL() {
+    return this._containerURL(this.presenterContainer);
+  }
+
+  contentURL() {
+    return this._containerURL(this.contentContainer);
+  }
+
+};

--- a/src/utils/ContentRepositoryUtil.js
+++ b/src/utils/ContentRepositoryUtil.js
@@ -41,4 +41,11 @@ export class ContentRepository {
     return this._containerURL(this.contentContainer);
   }
 
+  canSubmit() {
+    let hasContentContainer = !! this.contentContainer;
+    let isReady = this.state === "ready";
+
+    return hasContentContainer && isReady;
+  }
+
 };

--- a/src/utils/ContentRepositoryUtil.js
+++ b/src/utils/ContentRepositoryUtil.js
@@ -16,6 +16,7 @@ export class ContentRepository {
 
     this.contentContainer = null;
     this.presenterContainer = null;
+    this.preparerContainer = null;
   }
 
   name () {
@@ -46,6 +47,11 @@ export class ContentRepository {
     let isReady = this.state === "ready";
 
     return hasContentContainer && isReady;
+  }
+
+  reportError(message) {
+    this.state = "error";
+    this.error = message;
   }
 
 };

--- a/src/utils/DockerUtil.js
+++ b/src/utils/DockerUtil.js
@@ -350,5 +350,31 @@ export default {
 
       contentRepositoryActions.podLaunched({id, contentContainer, presenterContainer});
     });
+  },
+
+  launchPreparer (id, preparer, contentURL, contentRepoPath) {
+    let params = {
+      Volumes: {
+        "/usr/control-repo": {}
+      },
+      Env: [
+        "CONTENT_STORE_URL=" + contentURL,
+        "CONTENT_STORE_APIKEY=supersecret",
+        "TRAVIS_PULL_REQUEST=false"
+      ],
+      HostConfig: {
+        Binds: [contentRepoPath + ":/usr/control-repo"],
+        ReadonlyRootfs: true
+      }
+    };
+
+    this.run("preparer-" + id, "quay.io/deconst/preparer-" + preparer, "latest", params, (error, container) => {
+      if (error) {
+        contentRepositoryActions.error({id, error});
+        return;
+      }
+
+      contentRepositoryActions.preparerLaunched({id, container});
+    })
   }
 };

--- a/src/utils/DockerUtil.js
+++ b/src/utils/DockerUtil.js
@@ -162,6 +162,16 @@ export default {
           // Container destroyed
         } else if (data.id) {
           // Existing container updated
+          if (data.status === 'die') {
+            this.fetchContainer(data.id, (error, container) => {
+              if (error) {
+                console.error(error);
+                return;
+              }
+
+              contentRepositoryActions.containerCompleted({container});
+            });
+          }
         }
       });
     });

--- a/src/utils/DockerUtil.js
+++ b/src/utils/DockerUtil.js
@@ -299,7 +299,7 @@ export default {
     });
   },
 
-  launchServicePod (id, controlRepoPath) {
+  launchServicePod (repo) {
     let contentParams = {
       Env: [
         "NODE_ENV=development",
@@ -323,11 +323,12 @@ export default {
         "CONTROL_REPO_PATH=/var/control-repo",
         "CONTENT_SERVICE_URL=http://content:8080/",
         "PRESENTER_LOG_LEVEL=debug",
-        "PRESENTER_LOG_COLOR=true"
+        "PRESENTER_LOG_COLOR=true",
+        "PRESENTED_URL_DOMAIN=developer.rackspace.com",
       ],
       HostConfig: {
-        Binds: [ controlRepoPath + ":/var/control-repo:ro" ],
-        Links: [ "content-" + id + ":content" ],
+        Binds: [ repo.controlRepositoryLocation + ":/var/control-repo:ro" ],
+        Links: [ "content-" + repo.id + ":content" ],
         PublishAllPorts: true,
         ReadonlyRootfs: true
       }
@@ -335,46 +336,46 @@ export default {
 
     async.series([
       (cb) => {
-        this.run("content-" + id, "quay.io/deconst/content-service", "latest", contentParams, cb);
+        this.run("content-" + repo.id, "quay.io/deconst/content-service", "latest", contentParams, cb);
       },
       (cb) => {
-        this.run("presenter-" + id, "quay.io/deconst/presenter", "latest", presenterParams, cb);
+        this.run("presenter-" + repo.id, "quay.io/deconst/presenter", "latest", presenterParams, cb);
       }
     ], (error, containers) => {
       if (error) {
-        contentRepositoryActions.error({id, error});
+        contentRepositoryActions.error({repo, error});
         return;
       }
 
       let [contentContainer, presenterContainer] = containers;
 
-      contentRepositoryActions.podLaunched({id, contentContainer, presenterContainer});
+      contentRepositoryActions.podLaunched({repo, contentContainer, presenterContainer});
     });
   },
 
-  launchPreparer (id, preparer, contentURL, contentRepoPath) {
+  launchPreparer (repo) {
     let params = {
       Volumes: {
         "/usr/control-repo": {}
       },
       Env: [
-        "CONTENT_STORE_URL=" + contentURL,
+        "CONTENT_STORE_URL=" + repo.contentURL(),
         "CONTENT_STORE_APIKEY=supersecret",
         "TRAVIS_PULL_REQUEST=false"
       ],
       HostConfig: {
-        Binds: [contentRepoPath + ":/usr/control-repo"],
+        Binds: [repo.contentRepositoryPath + ":/usr/control-repo"],
         ReadonlyRootfs: true
       }
     };
 
-    this.run("preparer-" + id, "quay.io/deconst/preparer-" + preparer, "latest", params, (error, container) => {
+    this.run("preparer-" + repo.id, "quay.io/deconst/preparer-" + repo.preparer, "latest", params, (error, container) => {
       if (error) {
-        contentRepositoryActions.error({id, error});
+        contentRepositoryActions.error({repo, error});
         return;
       }
 
-      contentRepositoryActions.preparerLaunched({id, container});
+      contentRepositoryActions.preparerLaunched({repo, container});
     })
   }
 };

--- a/styles/content-repository-list.less
+++ b/styles/content-repository-list.less
@@ -22,6 +22,10 @@
       font-family: monospace;
     }
 
+    a.submit {
+      margin-right: 10px;
+    }
+
     .content-preview {
       .state {
         font-weight: bold;


### PR DESCRIPTION
Submit content from a content repository to the content store via a preparer, run in a Docker container.
- [x] Notice when the preparer container completes and update the repository state back to "ready".
- [x] Run the preparer once immediately after service pod setup. Flux makes this a pain.
- [x] Maybe style the UI for manual preparer submission less ugly?
