### PR TITLE
Persist content repositories across application restarts

### DIFF
--- a/src/actions/ContentRepositoryActions.js
+++ b/src/actions/ContentRepositoryActions.js
@@ -4,8 +4,8 @@ import ContentRepositoryUtil, {ContentRepository} from '../utils/ContentReposito
 
 class ContentRepositoryActions {
 
-  launch (controlRepositoryLocation, contentRepositoryPath, preparer) {
-    let repo = new ContentRepository(controlRepositoryLocation, contentRepositoryPath, preparer);
+  launch (id, controlRepositoryLocation, contentRepositoryPath, preparer) {
+    let repo = new ContentRepository(id, controlRepositoryLocation, contentRepositoryPath, preparer);
     this.dispatch({repo});
 
     ContentRepositoryUtil.launchServicePod(repo);

--- a/src/components/EditContentRepository.react.js
+++ b/src/components/EditContentRepository.react.js
@@ -51,12 +51,19 @@ var EditContentRepository = React.createClass({
   // "Create" or "Save"
   handleCommit: function () {
     if (this.state.isNew) {
-      ContentRepositoryActions.launch(this.state.controlRepositoryLocation,
-        this.state.contentRepositoryPath, this.state.preparer);
+      ContentRepositoryActions.launch(
+        null,
+        this.state.controlRepositoryLocation,
+        this.state.contentRepositoryPath,
+        this.state.preparer
+      );
     } else {
-      ContentRepositoryActions.edit(this.props.params.id,
-        this.state.controlRepositoryLocation, this.state.contentRepositoryPath,
-        this.state.preparer);
+      ContentRepositoryActions.edit(
+        this.props.params.id,
+        this.state.controlRepositoryLocation,
+        this.state.contentRepositoryPath,
+        this.state.preparer
+      );
     }
 
     this.transitionTo("repositoryList");

--- a/src/stores/ContentRepositoryStore.js
+++ b/src/stores/ContentRepositoryStore.js
@@ -12,6 +12,7 @@ class ContentRepositoryStore {
 
   onLaunch({repo}) {
     this.repositories[repo.id] = repo;
+    ContentRepositoryUtil.saveRepositories(this.repositories);
   }
 
   onEdit({id, controlRepositoryLocation, contentRepositoryPath, preparer}) {
@@ -34,6 +35,7 @@ class ContentRepositoryStore {
     r.state = "relaunching";
 
     ContentRepositoryUtil.relaunchContainers(r);
+    ContentRepositoryUtil.saveRepositories(this.repositories);
   }
 
   onPodLaunched({repo, contentContainer, presenterContainer}) {
@@ -71,6 +73,7 @@ class ContentRepositoryStore {
     delete this.repositories[repo.id];
 
     ContentRepositoryUtil.cleanContainers(repo);
+    ContentRepositoryUtil.saveRepositories(this.repositories);
   }
 
   onContentPreparerLaunched({repo, container}) {

--- a/src/stores/SetupStore.js
+++ b/src/stores/SetupStore.js
@@ -11,6 +11,7 @@ import setupUtil from '../utils/SetupUtil';
 import util from '../utils/Util';
 import assign from 'object-assign';
 import docker from '../utils/DockerUtil';
+import ContentRepositoryUtil from '../utils/ContentRepositoryUtil';
 
 var _currentStep = null;
 var _error = null;
@@ -211,6 +212,7 @@ var SetupStore = assign(Object.create(EventEmitter.prototype), {
         docker.setup(ip, machine.name());
         yield docker.waitForConnection();
         yield Promise.fromNode((cb) => docker.cleanAllContainers(cb));
+        yield Promise.fromNode((cb) => ContentRepositoryUtil.loadRepositories(cb));
         break;
       } catch (err) {
         err.message = util.removeSensitiveData(err.message);

--- a/src/utils/ContentRepositoryUtil.js
+++ b/src/utils/ContentRepositoryUtil.js
@@ -21,7 +21,7 @@ var lastID = 0;
 
 export class ContentRepository {
 
-  constructor (controlRepositoryLocation, contentRepositoryPath, preparer, id = null) {
+  constructor (id, controlRepositoryLocation, contentRepositoryPath, preparer) {
     this.id = id || lastID++;
     this.controlRepositoryLocation = controlRepositoryLocation;
     this.contentRepositoryPath = contentRepositoryPath;
@@ -32,6 +32,10 @@ export class ContentRepository {
     this.presenterContainer = null;
     this.contentPreparerContainer = null;
     this.controlPreparerContainer = null;
+
+    if (this.id > lastID) {
+      lastID = this.id + 1;
+    }
 
     // Parse the _deconst.json file to determine the content ID base.
     try {

--- a/src/utils/ContentRepositoryUtil.js
+++ b/src/utils/ContentRepositoryUtil.js
@@ -17,12 +17,12 @@ function normalize(contentID) {
   return contentID + "/";
 }
 
+var lastID = 0;
+
 export class ContentRepository {
 
   constructor (controlRepositoryLocation, contentRepositoryPath, preparer) {
-    let lastID = parseInt(sessionStorage.getItem('content-repository-id') || '0');
-    let id = lastID + 1;
-    sessionStorage.setItem('content-repository-id', id.toString())
+    let id = lastID++;
 
     this.id = id;
     this.controlRepositoryLocation = controlRepositoryLocation;


### PR DESCRIPTION
Save the user's content repositories in a JSON file beneath `~/.deconst` and restore them to working order on launch.
