### PR TITLE
Explicitly configure a repository's display name.

### DIFF
--- a/src/actions/ContentRepositoryActions.js
+++ b/src/actions/ContentRepositoryActions.js
@@ -4,15 +4,23 @@ import ContentRepositoryUtil, {ContentRepository} from '../utils/ContentReposito
 
 class ContentRepositoryActions {
 
-  launch (id, controlRepositoryLocation, contentRepositoryPath, preparer) {
-    let repo = new ContentRepository(id, controlRepositoryLocation, contentRepositoryPath, preparer);
+  launch (id, displayName, controlRepositoryLocation, contentRepositoryPath, preparer) {
+    let repo = new ContentRepository(
+      id, displayName,
+      controlRepositoryLocation, contentRepositoryPath,
+      preparer
+    );
     this.dispatch({repo});
 
     ContentRepositoryUtil.launchServicePod(repo);
   }
 
-  edit (id, controlRepositoryLocation, contentRepositoryPath, preparer) {
-    this.dispatch({id, controlRepositoryLocation, contentRepositoryPath, preparer});
+  edit (id, displayName, controlRepositoryLocation, contentRepositoryPath, preparer) {
+    this.dispatch({
+      id, displayName,
+      controlRepositoryLocation, contentRepositoryPath,
+      preparer
+    });
   }
 
   prepareContent (repo) {

--- a/src/browser.js
+++ b/src/browser.js
@@ -46,8 +46,8 @@ if (process.platform === 'win32') {
 
 app.on('ready', function () {
   var mainWindow = new BrowserWindow({
-    width: size.width || 800,
-    height: size.height || 600,
+    width: size.width || 600,
+    height: size.height || 650,
     'min-width': os.platform() === 'win32' ? 400 : 600,
     'min-height': os.platform() === 'win32' ? 260 : 100,
     resizable: true,

--- a/src/components/EditContentRepository.react.js
+++ b/src/components/EditContentRepository.react.js
@@ -98,9 +98,12 @@ var EditContentRepository = React.createClass({
 
   // "Create" or "Save"
   handleCommit: function () {
+    let displayName = this.state.manualDisplayName ? this.state.displayName : null;
+
     if (this.state.isNew) {
       ContentRepositoryActions.launch(
         null,
+        displayName,
         this.state.controlRepositoryLocation,
         this.state.contentRepositoryPath,
         this.state.preparer
@@ -108,6 +111,7 @@ var EditContentRepository = React.createClass({
     } else {
       ContentRepositoryActions.edit(
         this.props.params.id,
+        displayName,
         this.state.controlRepositoryLocation,
         this.state.contentRepositoryPath,
         this.state.preparer

--- a/src/components/EditContentRepository.react.js
+++ b/src/components/EditContentRepository.react.js
@@ -1,3 +1,4 @@
+import path from 'path';
 import React from 'react/addons';
 import Router from 'react-router';
 import remote from 'remote';
@@ -16,6 +17,8 @@ var EditContentRepository = React.createClass({
   getInitialState: function () {
     return {
       isNew: true,
+      manualDisplayName: false,
+      displayName: null,
       contentRepositoryPath: null,
       controlRepositoryLocation: lastControlRepository,
       preparer: "sphinx"
@@ -30,11 +33,22 @@ var EditContentRepository = React.createClass({
 
       this.setState({
         isNew: false,
+        displayName: repo.displayName,
         contentRepositoryPath: repo.contentRepositoryPath,
         controlRepositoryLocation: repo.controlRepositoryLocation,
         preparer: repo.preparer
       });
     }
+  },
+
+  updateContentRepository: function (repoPath) {
+    let nstate = {contentRepositoryPath: repoPath};
+
+    if (!this.state.manualDisplayName) {
+      nstate.displayName = path.basename(nstate.contentRepositoryPath);
+    }
+
+    this.setState(nstate);
   },
 
   handleOpenContent: function() {
@@ -44,7 +58,7 @@ var EditContentRepository = React.createClass({
     });
 
     if (results && results.length > 0) {
-      this.setState({contentRepositoryPath: results[0]});
+      this.updateContentRepository(results[0]);
     }
   },
 
@@ -59,8 +73,15 @@ var EditContentRepository = React.createClass({
     }
   },
 
+  handleDisplayNameChange: function (e) {
+    this.setState({
+      manualDisplayName: true,
+      displayName: e.target.value
+    });
+  },
+
   handleRepositoryPathChange: function (e) {
-    this.setState({contentRepositoryPath: e.target.value});
+    this.updateContentRepository(e.target.value);
   },
 
   handleControlRepositoryChange: function (e) {
@@ -106,10 +127,15 @@ var EditContentRepository = React.createClass({
       <div className="edit-content-repository">
         <div className="container">
           <h1>{banner}</h1>
+          <div className="display-name">
+            <h3>Display Name</h3>
+            <p className="explanation">Name that will appear in the repository list in this app.</p>
+            <input type="text" className="line" value={this.state.displayName} onChange={this.handleDisplayNameChange}></input>
+          </div>
           <div className="repository-path">
             <h3>Content Repository Path</h3>
             <p className="explanation">Filesystem path to the content repository.</p>
-            <input type="text" className="line" value={this.state.contentRepositoryPath} placeholder="/some/path" onChange={this.handleRepositoryPathChange}></input>
+            <input type="text" className="line fs-path" value={this.state.contentRepositoryPath} placeholder="/some/path" onChange={this.handleRepositoryPathChange}></input>
             <button className="btn btn-default btn-sm browse" onClick={this.handleOpenContent}>browse</button>
           </div>
           <div className="control-repository">
@@ -117,7 +143,7 @@ var EditContentRepository = React.createClass({
             <p className="explanation">
               Location of the control repository. May be either a git URL or a local filesystem path.
             </p>
-            <input type="text" className="line" value={this.state.controlRepositoryLocation} placeholder="https://github.com/deconst/deconst-docs-control.git" onChange={this.handleControlRepositoryChange}></input>
+            <input type="text" className="line fs-path" value={this.state.controlRepositoryLocation} placeholder="https://github.com/deconst/deconst-docs-control.git" onChange={this.handleControlRepositoryChange}></input>
             <button className="btn btn-default btn-sm browse" onClick={this.handleOpenControl}>browse</button>
           </div>
           <div className="preparer">

--- a/src/components/EditContentRepository.react.js
+++ b/src/components/EditContentRepository.react.js
@@ -33,7 +33,8 @@ var EditContentRepository = React.createClass({
 
       this.setState({
         isNew: false,
-        displayName: repo.displayName,
+        manualDisplayName: !! repo.displayName,
+        displayName: repo.name(),
         contentRepositoryPath: repo.contentRepositoryPath,
         controlRepositoryLocation: repo.controlRepositoryLocation,
         preparer: repo.preparer

--- a/src/components/EditContentRepository.react.js
+++ b/src/components/EditContentRepository.react.js
@@ -135,7 +135,7 @@ var EditContentRepository = React.createClass({
           <div className="display-name">
             <h3>Display Name</h3>
             <p className="explanation">Name that will appear in the repository list in this app.</p>
-            <input type="text" className="line" value={this.state.displayName} onChange={this.handleDisplayNameChange}></input>
+            <input type="text" className="line" value={this.state.displayName} placeholder="derived from content repository path" onChange={this.handleDisplayNameChange}></input>
           </div>
           <div className="repository-path">
             <h3>Content Repository Path</h3>

--- a/src/stores/ContentRepositoryStore.js
+++ b/src/stores/ContentRepositoryStore.js
@@ -18,12 +18,13 @@ class ContentRepositoryStore {
     ContentRepositoryUtil.saveRepositories(this.repositories);
   }
 
-  onEdit({id, controlRepositoryLocation, contentRepositoryPath, preparer}) {
+  onEdit({id, displayName, controlRepositoryLocation, contentRepositoryPath, preparer}) {
     let r = this.repositories[id];
     if (!r) {
       return;
     }
-    let changed = (controlRepositoryLocation !== r.controlRepositoryLocation);
+    let changed = (displayName !== r.displayName);
+    changed = changed || (controlRepositoryLocation !== r.controlRepositoryLocation);
     changed = changed || (contentRepositoryPath !== r.contentRepositoryPath);
     changed = changed || (preparer !== r.preparer);
 
@@ -31,6 +32,7 @@ class ContentRepositoryStore {
       return;
     }
 
+    r.displayName = displayName;
     r.controlRepositoryLocation = controlRepositoryLocation;
     r.contentRepositoryPath = contentRepositoryPath;
     r.preparer = preparer;

--- a/src/utils/ContentRepositoryUtil.js
+++ b/src/utils/ContentRepositoryUtil.js
@@ -23,8 +23,9 @@ let repositoriesPath = path.join(osenv.home(), '.deconst', 'repositories.json');
 
 export class ContentRepository {
 
-  constructor (id, controlRepositoryLocation, contentRepositoryPath, preparer) {
+  constructor (id, displayName, controlRepositoryLocation, contentRepositoryPath, preparer) {
     this.id = id || lastID++;
+    this.displayName = displayName;
     this.controlRepositoryLocation = controlRepositoryLocation;
     this.contentRepositoryPath = contentRepositoryPath;
     this.state = "launching";
@@ -101,7 +102,7 @@ export class ContentRepository {
   }
 
   name () {
-    return path.basename(this.contentRepositoryPath);
+    return this.displayName || path.basename(this.contentRepositoryPath);
   }
 
   _containerURL(container, ...rest) {

--- a/src/utils/ContentRepositoryUtil.js
+++ b/src/utils/ContentRepositoryUtil.js
@@ -169,6 +169,7 @@ export class ContentRepository {
   serialize() {
     return {
       id: this.id,
+      displayName: this.displayName,
       controlRepositoryLocation: this.controlRepositoryLocation,
       contentRepositoryPath: this.contentRepositoryPath,
       preparer: this.preparer
@@ -178,15 +179,6 @@ export class ContentRepository {
   reportError(message) {
     this.state = "error";
     this.error = message;
-  }
-
-  static deserialize({id, controlRepositoryLocation, contentRepositoryPath, preparer}) {
-    return new ContentRepository(
-      controlRepositoryLocation,
-      contentRepositoryPath,
-      preparer,
-      id
-    );
   }
 
 };
@@ -373,6 +365,7 @@ export default {
           if (wellFormed) {
             ContentRepositoryActions.launch(
               repoDoc.id,
+              repoDoc.displayName || null,
               repoDoc.controlRepositoryLocation,
               repoDoc.contentRepositoryPath,
               repoDoc.preparer

--- a/styles/edit-content-repository.less
+++ b/styles/edit-content-repository.less
@@ -6,7 +6,11 @@
 
   input.line {
     display: inline-block;
-    width: 80%;
+    width: 100%;
+
+    &.fs-path {
+      width: 80%;
+    }
   }
 
   button.browse {


### PR DESCRIPTION
When creating or editing a content repository, allow users to edit the automatically generated display name.

Fixes deconst/deconst-docs#143.
