### PR TITLE
Wait for the initial preparers to complete

### DIFF
--- a/src/stores/ContentRepositoryStore.js
+++ b/src/stores/ContentRepositoryStore.js
@@ -150,6 +150,7 @@ class ContentRepositoryStore {
         r.contentPreparerContainer = null;
         if (!r.isPreparing()) {
           r.state = "ready";
+          r.hasPrepared = true;
         }
       }
 
@@ -158,6 +159,7 @@ class ContentRepositoryStore {
         r.controlPreparerContainer = null;
         if (!r.isPreparing()) {
           r.state = "ready";
+          r.hasPrepared = true;
         }
       }
 

--- a/src/utils/ContentRepositoryUtil.js
+++ b/src/utils/ContentRepositoryUtil.js
@@ -136,7 +136,7 @@ export class ContentRepository {
   canPreview() {
     let hasPresenterContainer = !! this.presenterContainer;
 
-    return hasPresenterContainer;
+    return hasPresenterContainer && this.hasPrepared;
   }
 
   isPreparing() {

--- a/src/utils/ContentRepositoryUtil.js
+++ b/src/utils/ContentRepositoryUtil.js
@@ -28,8 +28,10 @@ export class ContentRepository {
     this.displayName = displayName;
     this.controlRepositoryLocation = controlRepositoryLocation;
     this.contentRepositoryPath = contentRepositoryPath;
-    this.state = "launching";
     this.preparer = preparer;
+
+    this.state = "launching";
+    this.hasPrepared = false;
 
     this.contentContainer = null;
     this.presenterContainer = null;


### PR DESCRIPTION
Don't activate the preview link until the initial content and control preparers have completed, so you don't see a 404 or unstyled content by clicking too soon.

Fixes deconst/deconst-docs#144.
