### PR TITLE
Add npm-debug.log to the always-ignored list.

### DIFF
--- a/src/stores/ContentRepositoryStore.js
+++ b/src/stores/ContentRepositoryStore.js
@@ -59,7 +59,7 @@ class ContentRepositoryStore {
     prepareControl();
 
     let installWatcher = (root, fn, callback) => {
-      let ignored = ['_build/**', '_site/**', '.git/**', '.DS_Store', 'build'];
+      let ignored = ['_build/**', '_site/**', '.git/**', '.DS_Store', 'npm-debug.log', 'build'];
       let gitignorePath = path.join(root, ".gitignore");
 
       fs.readFile(gitignorePath, {encoding: 'utf-8'}, (error, content) => {


### PR DESCRIPTION
Fixes deconst/deconst-docs#154.
