### PR TITLE
Adapt to control repo npm installation

### DIFF
--- a/src/stores/ContentRepositoryStore.js
+++ b/src/stores/ContentRepositoryStore.js
@@ -56,7 +56,8 @@ class ContentRepositoryStore {
     ContentRepositoryUtil.launchControlPreparer(r);
 
     let installWatcher = (root, fn, callback) => {
-      let ignored = ['_build/**', '_site/**', '.git/**', '.DS_Store', 'npm-debug.log', 'build'];
+      let ignored = ['_build/**', '_site/**', '.git/**', '.DS_Store', 'npm-debug.log', 'build',
+        '**/node_modules/**'];
       let gitignorePath = path.join(root, ".gitignore");
 
       fs.readFile(gitignorePath, {encoding: 'utf-8'}, (error, content) => {

--- a/src/stores/ContentRepositoryStore.js
+++ b/src/stores/ContentRepositoryStore.js
@@ -52,11 +52,8 @@ class ContentRepositoryStore {
     r.contentContainer = contentContainer;
     r.presenterContainer = presenterContainer;
 
-    let prepareContent = () => ContentRepositoryUtil.launchContentPreparer(r);
-    let prepareControl = () => ContentRepositoryUtil.launchControlPreparer(r);
-
-    prepareContent();
-    prepareControl();
+    ContentRepositoryUtil.launchContentPreparer(r);
+    ContentRepositoryUtil.launchControlPreparer(r);
 
     let installWatcher = (root, fn, callback) => {
       let ignored = ['_build/**', '_site/**', '.git/**', '.DS_Store', 'npm-debug.log', 'build'];
@@ -83,7 +80,16 @@ class ContentRepositoryStore {
       });
     };
 
+    let prepareContent = (path) => {
+      console.log("Launching content preparer because of a change to: " + path);
+      ContentRepositoryUtil.launchContentPreparer(r)
+    };
     installWatcher(r.contentRepositoryPath, prepareContent, (w) => r.contentWatcher = w);
+
+    let prepareControl = (path) => {
+      console.log("Launching control preparer because of a change to: " + path);
+      ContentRepositoryUtil.launchControlPreparer(r);
+    };
     installWatcher(r.controlRepositoryLocation, prepareControl, (w) => r.controlWatcher = w);
   }
 

--- a/src/utils/ContentRepositoryUtil.js
+++ b/src/utils/ContentRepositoryUtil.js
@@ -232,7 +232,7 @@ export default {
       ],
       HostConfig: {
         Binds: [
-          repo.controlRepositoryLocation + ':/var/control-repo:ro',
+          repo.controlRepositoryLocation + ':/var/control-repo',
           controlOverrideDir + ':/var/override:ro'
         ],
         Links: [ "content-" + repo.id + ":content" ],


### PR DESCRIPTION
In deconst/presenter#65, deconst/presenter#68, and other related changes, the presenter now runs `npm install` in plugin subdirectories of the control repository. This means that the presenter needs read-write access to the control repository, which the client did not previously do.
