### PR TITLE
Report preparer errors

### DIFF
--- a/src/stores/ContentRepositoryStore.js
+++ b/src/stores/ContentRepositoryStore.js
@@ -174,6 +174,8 @@ class ContentRepositoryStore {
       }
 
       if (r.controlPreparerContainer && r.controlPreparerContainer.Id === container.Id) {
+        console.log(`Exit status: ${container.State.ExitCode}`);
+
         // The control preparer has completed.
         r.controlPreparerContainer = null;
         if (!r.isPreparing()) {

--- a/src/stores/ContentRepositoryStore.js
+++ b/src/stores/ContentRepositoryStore.js
@@ -165,22 +165,38 @@ class ContentRepositoryStore {
     for(let id in this.repositories) {
       let r = this.repositories[id];
       if (r.contentPreparerContainer && r.contentPreparerContainer.Id === container.Id) {
-        // This repository's preparer has completed.
         r.contentPreparerContainer = null;
-        if (!r.isPreparing()) {
-          r.state = "ready";
-          r.hasPrepared = true;
+
+        // This repository's preparer has completed.
+        if (container.State.ExitCode === 0) {
+          // Clean exit. Hooray!
+          if (!r.isPreparing()) {
+            r.state = "ready";
+            r.hasPrepared = true;
+          }
+        } else if (container.State.ExitCode === 137) {
+          // Killed, presumably to run a new preparer.
+        } else {
+          // Boom! Something went wrong.
+          r.reportError(`The content preparer exited with status ${container.State.ExitCode}.`);
         }
       }
 
       if (r.controlPreparerContainer && r.controlPreparerContainer.Id === container.Id) {
-        console.log(`Exit status: ${container.State.ExitCode}`);
-
         // The control preparer has completed.
         r.controlPreparerContainer = null;
-        if (!r.isPreparing()) {
-          r.state = "ready";
-          r.hasPrepared = true;
+
+        if (container.State.ExitCode === 0) {
+          // Clean exit. Hooray!
+          if (!r.isPreparing()) {
+            r.state = "ready";
+            r.hasPrepared = true;
+          }
+        } else if (container.State.ExitCode === 137) {
+          // Killed, presumably to run a new preparer.
+        } else {
+          // Boom! Something went wrong.
+          r.reportError(`The control preparer exited with status ${container.State.ExitCode}.`);
         }
       }
 


### PR DESCRIPTION
This notices when a preparer has completed unsuccessfully. We'll need deconst/deconst-docs#153 to be able to actually diagnose what went wrong, but at least this will let you know that something's up without just giving you unstyled content or 404s.

![screen shot 2015-08-31 at 9 15 22 am](https://cloud.githubusercontent.com/assets/17565/9579501/1f759c72-4fc1-11e5-9192-edb92299030e.jpeg)
