### PR TITLE
Bounce the app icon on preparer completion

### DIFF
--- a/src/browser.js
+++ b/src/browser.js
@@ -69,6 +69,10 @@ app.on('ready', function () {
     autoUpdater.quitAndInstall();
   });
 
+  ipc.on('deconst:preparer-completion', function () {
+    app.dock.bounce();
+  });
+
   if (os.platform() === 'win32') {
     mainWindow.on('close', function () {
       mainWindow.webContents.send('application:quitting');

--- a/src/browser.js
+++ b/src/browser.js
@@ -70,7 +70,9 @@ app.on('ready', function () {
   });
 
   ipc.on('deconst:preparer-completion', function () {
-    app.dock.bounce();
+    if (!mainWindow || !mainWindow.isFocused()) {
+      app.dock.bounce();
+    }
   });
 
   if (os.platform() === 'win32') {

--- a/src/stores/ContentRepositoryStore.js
+++ b/src/stores/ContentRepositoryStore.js
@@ -56,7 +56,7 @@ class ContentRepositoryStore {
     ContentRepositoryUtil.launchControlPreparer(r);
 
     let installWatcher = (root, fn, callback) => {
-      let ignored = ['_build/**', '_site/**', '.git/**', '.DS_Store', 'npm-debug.log', 'build',
+      let ignored = ['_build/**', '_site/**', '.git/**', '.DS_Store', 'npm-debug.log*', 'build',
         '**/node_modules/**'];
       let gitignorePath = path.join(root, ".gitignore");
 

--- a/src/stores/ContentRepositoryStore.js
+++ b/src/stores/ContentRepositoryStore.js
@@ -164,38 +164,13 @@ class ContentRepositoryStore {
     // Identify which repository this container belongs to, if any.
     for(let id in this.repositories) {
       let r = this.repositories[id];
-      if (r.contentPreparerContainer && r.contentPreparerContainer.Id === container.Id) {
-        r.contentPreparerContainer = null;
 
-        // This repository's preparer has completed.
-        if (container.State.ExitCode === 0) {
-          // Clean exit. Hooray!
-          if (!r.isPreparing()) {
-            r.reportPreparerComplete();
-          }
-        } else if (container.State.ExitCode === 137) {
-          // Killed, presumably to run a new preparer.
-        } else {
-          // Boom! Something went wrong.
-          r.reportError(`The content preparer exited with status ${container.State.ExitCode}.`);
-        }
+      if (r.contentPreparerContainer && r.contentPreparerContainer.Id === container.Id) {
+        r.reportPreparerComplete(container);
       }
 
       if (r.controlPreparerContainer && r.controlPreparerContainer.Id === container.Id) {
-        // The control preparer has completed.
-        r.controlPreparerContainer = null;
-
-        if (container.State.ExitCode === 0) {
-          // Clean exit. Hooray!
-          if (!r.isPreparing()) {
-            r.reportPreparerComplete();
-          }
-        } else if (container.State.ExitCode === 137) {
-          // Killed, presumably to run a new preparer.
-        } else {
-          // Boom! Something went wrong.
-          r.reportError(`The control preparer exited with status ${container.State.ExitCode}.`);
-        }
+        r.reportPreparerComplete(container);
       }
 
       if (r.contentContainer && r.contentContainer.Id === container.Id) {

--- a/src/stores/ContentRepositoryStore.js
+++ b/src/stores/ContentRepositoryStore.js
@@ -171,8 +171,7 @@ class ContentRepositoryStore {
         if (container.State.ExitCode === 0) {
           // Clean exit. Hooray!
           if (!r.isPreparing()) {
-            r.state = "ready";
-            r.hasPrepared = true;
+            r.reportPreparerComplete();
           }
         } else if (container.State.ExitCode === 137) {
           // Killed, presumably to run a new preparer.
@@ -189,8 +188,7 @@ class ContentRepositoryStore {
         if (container.State.ExitCode === 0) {
           // Clean exit. Hooray!
           if (!r.isPreparing()) {
-            r.state = "ready";
-            r.hasPrepared = true;
+            r.reportPreparerComplete();
           }
         } else if (container.State.ExitCode === 137) {
           // Killed, presumably to run a new preparer.

--- a/src/utils/ContentRepositoryUtil.js
+++ b/src/utils/ContentRepositoryUtil.js
@@ -7,6 +7,7 @@ import mkdirp from 'mkdirp';
 import osenv from 'osenv';
 import urlJoin from 'url-join';
 import _ from 'underscore';
+import ipc from 'ipc';
 
 import DockerUtil from './DockerUtil';
 import ContentRepositoryActions from '../actions/ContentRepositoryActions';
@@ -176,6 +177,12 @@ export class ContentRepository {
       contentRepositoryPath: this.contentRepositoryPath,
       preparer: this.preparer
     };
+  }
+
+  reportPreparerComplete() {
+    this.state = "ready";
+    this.hasPrepared = true;
+    ipc.send('deconst:preparer-completion');
   }
 
   reportError(message) {


### PR DESCRIPTION
A reworking on #20. Now that we're watching the preparer's exit code with #25, we can bounce the icon only when we want it to.

Fixes deconst/deconst-docs#145.
