### PR TITLE
Don't claim we can use git URLs for the control repo.

### DIFF
--- a/src/components/EditContentRepository.react.js
+++ b/src/components/EditContentRepository.react.js
@@ -145,9 +145,7 @@ var EditContentRepository = React.createClass({
           </div>
           <div className="control-repository">
             <h3>Control Repository Location</h3>
-            <p className="explanation">
-              Location of the control repository. May be either a git URL or a local filesystem path.
-            </p>
+            <p className="explanation">Filesystem path to the control repository.</p>
             <input type="text" className="line fs-path" value={this.state.controlRepositoryLocation} placeholder="https://github.com/deconst/deconst-docs-control.git" onChange={this.handleControlRepositoryChange}></input>
             <button className="btn btn-default btn-sm browse" onClick={this.handleOpenControl}>browse</button>
           </div>


### PR DESCRIPTION
I'm intending to support git URLs and branch names for the control repo, so you don't have to clone it by hand if you don't have another reason to keep it around, but you can't do that yet. This updates the hint text on the content repository editor to reflect that.

I can just revert this once deconst/deconst-docs#152 is in.
