### PR TITLE
Map /usr/content-repo, not /usr/control-repo.

### DIFF
--- a/src/utils/ContentRepositoryUtil.js
+++ b/src/utils/ContentRepositoryUtil.js
@@ -308,7 +308,7 @@ export default {
         "TRAVIS_PULL_REQUEST=false"
       ],
       HostConfig: {
-        Binds: [repo.contentRepositoryPath + ":/usr/control-repo"],
+        Binds: [repo.contentRepositoryPath + ":/usr/content-repo"],
         ReadonlyRootfs: true
       }
     };


### PR DESCRIPTION
This will fix the preparer runs to accommodate deconst/preparer-sphinx#35 and deconst/preparer-jekyll#20.
