### PR TITLE
Upgrade Electron the version released two hours ago.

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   ],
   "docker-version": "1.8.0-rc2",
   "docker-machine-version": "0.4.1",
-  "electron-version": "0.30.6",
+  "electron-version": "0.33.0",
   "virtualbox-version": "5.0.0",
   "virtualbox-filename": "VirtualBox-5.0.0.pkg",
   "virtualbox-filename-win": "VirtualBox-5.0.0.exe",
@@ -66,7 +66,7 @@
   "devDependencies": {
     "babel": "^5.1.10",
     "babel-jest": "^5.2.0",
-    "electron-prebuilt": "^0.27.3",
+    "electron-prebuilt": "0.33.0",
     "grunt": "^0.4.5",
     "grunt-babel": "^5.0.1",
     "grunt-chmod": "^1.0.3",


### PR DESCRIPTION
It's good to do this once in a while anyway, but it _might_ help the crash from deconst/deconst-docs#166.
