### PR TITLE
Start a smaller VM

### DIFF
--- a/src/utils/DockerMachineUtil.js
+++ b/src/utils/DockerMachineUtil.js
@@ -54,7 +54,7 @@ var DockerMachine = {
     });
   },
   create: function (machineName = this.name()) {
-    return util.exec([this.command(), '-D', 'create', '-d', 'virtualbox', '--virtualbox-memory', '2048', machineName]);
+    return util.exec([this.command(), '-D', 'create', '-d', 'virtualbox', '--virtualbox-memory', '512', machineName]);
   },
   start: function (machineName = this.name()) {
     return util.exec([this.command(), '-D', 'start', machineName]);

--- a/src/utils/DockerMachineUtil.js
+++ b/src/utils/DockerMachineUtil.js
@@ -54,7 +54,7 @@ var DockerMachine = {
     });
   },
   create: function (machineName = this.name()) {
-    return util.exec([this.command(), '-D', 'create', '-d', 'virtualbox', '--virtualbox-memory', '512', machineName]);
+    return util.exec([this.command(), '-D', 'create', '-d', 'virtualbox', machineName]);
   },
   start: function (machineName = this.name()) {
     return util.exec([this.command(), '-D', 'start', machineName]);


### PR DESCRIPTION
This launches a smaller Virtualbox VM. We don't actually need 2GB of RAM unless you want to build a _lot_ of content repositories at once.
