### PR TITLE
Basic validation of content repository inputs.

### DIFF
--- a/src/components/EditContentRepository.react.js
+++ b/src/components/EditContentRepository.react.js
@@ -5,7 +5,7 @@ import remote from 'remote';
 
 var dialog = remote.require('dialog');
 
-import {ContentRepository} from '../utils/ContentRepositoryUtil';
+import {ContentRepository, validateContentRepository} from '../utils/ContentRepositoryUtil';
 import ContentRepositoryActions from '../actions/ContentRepositoryActions';
 import ContentRepositoryStore from '../stores/ContentRepositoryStore';
 
@@ -21,7 +21,12 @@ var EditContentRepository = React.createClass({
       displayName: null,
       contentRepositoryPath: null,
       controlRepositoryLocation: lastControlRepository,
-      preparer: "sphinx"
+      preparer: "sphinx",
+      validationErrors: {
+        displayName: [],
+        controlRepositoryLocation: [],
+        contentRepositoryPath: []
+      },
     };
   },
 
@@ -42,6 +47,19 @@ var EditContentRepository = React.createClass({
     }
   },
 
+  revalidate: function (nstate) {
+    this.setState(nstate, () => {
+      validateContentRepository(this.state, (err, results) => {
+        if (err) {
+          console.error(err);
+          return;
+        }
+
+        this.setState({validationErrors: results});
+      });
+    });
+  },
+
   updateContentRepository: function (repoPath) {
     let nstate = {contentRepositoryPath: repoPath};
 
@@ -49,7 +67,7 @@ var EditContentRepository = React.createClass({
       nstate.displayName = path.basename(nstate.contentRepositoryPath);
     }
 
-    this.setState(nstate);
+    this.revalidate(nstate);
   },
 
   handleOpenContent: function() {
@@ -70,12 +88,12 @@ var EditContentRepository = React.createClass({
     });
 
     if (results && results.length > 0) {
-      this.setState({controlRepositoryLocation: results[0]});
+      this.revalidate({controlRepositoryLocation: results[0]});
     }
   },
 
   handleDisplayNameChange: function (e) {
-    this.setState({
+    this.revalidate({
       manualDisplayName: true,
       displayName: e.target.value
     });
@@ -86,11 +104,11 @@ var EditContentRepository = React.createClass({
   },
 
   handleControlRepositoryChange: function (e) {
-    this.setState({controlRepositoryLocation: e.target.value});
+    this.revalidate({controlRepositoryLocation: e.target.value});
   },
 
   handlePreparerChange: function (e) {
-    this.setState({preparer: e.target.value});
+    this.revalidate({preparer: e.target.value});
   },
 
   handleCancel: function () {

--- a/src/components/EditContentRepository.react.js
+++ b/src/components/EditContentRepository.react.js
@@ -146,40 +146,77 @@ var EditContentRepository = React.createClass({
     let banner = this.state.isNew ? "Add a Content Repository" : "Edit the Content Repository";
     let commit = this.state.isNew ? "Create" : "Save";
 
+    let displayNameSection = this.renderSection("displayName", "display-name", (
+      <div>
+        <h3>Display Name</h3>
+        <p className="explanation">Name that will appear in the repository list in this app.</p>
+        <input type="text" className="line" value={this.state.displayName} placeholder="derived from content repository path" onChange={this.handleDisplayNameChange}></input>
+      </div>
+    ));
+
+    let repositoryPathSection = this.renderSection("contentRepositoryPath", "content-repository-path", (
+      <div>
+        <h3>Content Repository Path</h3>
+        <p className="explanation">Filesystem path to the content repository.</p>
+        <input type="text" className="line fs-path" value={this.state.contentRepositoryPath} placeholder="/some/path" onChange={this.handleRepositoryPathChange}></input>
+        <button className="btn btn-default btn-sm browse" onClick={this.handleOpenContent}>browse</button>
+      </div>
+    ));
+
+    let controlRepositorySection = this.renderSection("controlRepositoryLocation", "control-repository-location", (
+      <div>
+        <h3>Control Repository Location</h3>
+        <p className="explanation">Filesystem path to the control repository.</p>
+        <input type="text" className="line fs-path" value={this.state.controlRepositoryLocation} placeholder="https://github.com/deconst/deconst-docs-control.git" onChange={this.handleControlRepositoryChange}></input>
+        <button className="btn btn-default btn-sm browse" onClick={this.handleOpenControl}>browse</button>
+      </div>
+    ));
+
+    let preparerSection = this.renderSection("preparer", "preparer", (
+      <div>
+        <h3>Preparer</h3>
+        <p className="explanation">Preparer to use to prepare the content.</p>
+        <select value={this.state.preparer} onChange={this.handlePreparerChange}>
+          <option value="sphinx">Sphinx</option>
+          <option value="jekyll">Jekyll</option>
+        </select>
+      </div>
+    ));
+
     return (
       <div className="edit-content-repository">
         <div className="container">
           <h1>{banner}</h1>
-          <div className="display-name">
-            <h3>Display Name</h3>
-            <p className="explanation">Name that will appear in the repository list in this app.</p>
-            <input type="text" className="line" value={this.state.displayName} placeholder="derived from content repository path" onChange={this.handleDisplayNameChange}></input>
-          </div>
-          <div className="repository-path">
-            <h3>Content Repository Path</h3>
-            <p className="explanation">Filesystem path to the content repository.</p>
-            <input type="text" className="line fs-path" value={this.state.contentRepositoryPath} placeholder="/some/path" onChange={this.handleRepositoryPathChange}></input>
-            <button className="btn btn-default btn-sm browse" onClick={this.handleOpenContent}>browse</button>
-          </div>
-          <div className="control-repository">
-            <h3>Control Repository Location</h3>
-            <p className="explanation">Filesystem path to the control repository.</p>
-            <input type="text" className="line fs-path" value={this.state.controlRepositoryLocation} placeholder="https://github.com/deconst/deconst-docs-control.git" onChange={this.handleControlRepositoryChange}></input>
-            <button className="btn btn-default btn-sm browse" onClick={this.handleOpenControl}>browse</button>
-          </div>
-          <div className="preparer">
-            <h3>Preparer</h3>
-            <p className="explanation">Preparer to use to prepare the content.</p>
-            <select value={this.state.preparer} onChange={this.handlePreparerChange}>
-              <option value="sphinx">Sphinx</option>
-              <option value="jekyll">Jekyll</option>
-            </select>
-          </div>
+          {displayNameSection}
+          {repositoryPathSection}
+          {controlRepositorySection}
+          {preparerSection}
           <div className="controls">
             <button className="btn btn-large btn-default" onClick={this.handleCancel}>Cancel</button>
             <button className="btn btn-large btn-primary" onClick={this.handleCommit}>{commit}</button>
           </div>
         </div>
+      </div>
+    )
+  },
+
+  renderSection: function (componentName, className, inner) {
+    let errorMessages = this.state.validationErrors[componentName] || [];
+    let klasses = className;
+    let errorElement;
+
+    if (errorMessages.length > 0) {
+      klasses = `${klasses} with-errors`;
+
+      errorElement = (
+        <div className="validation-errors">{errorMessages.join(" ")}</div>
+      );
+    }
+
+    return (
+      <div className={klasses}>
+        {inner}
+        {errorElement}
       </div>
     )
   }

--- a/src/components/EditContentRepository.react.js
+++ b/src/components/EditContentRepository.react.js
@@ -22,6 +22,7 @@ var EditContentRepository = React.createClass({
       contentRepositoryPath: null,
       controlRepositoryLocation: lastControlRepository,
       preparer: "sphinx",
+      canCreate: false,
       validationErrors: {
         displayName: [],
         controlRepositoryLocation: [],
@@ -55,7 +56,14 @@ var EditContentRepository = React.createClass({
           return;
         }
 
-        this.setState({validationErrors: results});
+        let validationErrorCount = Object.keys(results).reduce((sum, k) => sum + results[k].length, 0);
+
+        let canCreate = validationErrorCount === 0 &&
+          this.state.displayName !== null &&
+          this.state.contentRepositoryPath !== null &&
+          this.state.controlRepositoryLocation !== null;
+
+        this.setState({validationErrors: results, canCreate});
       });
     });
   },
@@ -193,7 +201,7 @@ var EditContentRepository = React.createClass({
           {preparerSection}
           <div className="controls">
             <button className="btn btn-large btn-default" onClick={this.handleCancel}>Cancel</button>
-            <button className="btn btn-large btn-primary" onClick={this.handleCommit}>{commit}</button>
+            <button className="btn btn-large btn-primary" onClick={this.handleCommit} disabled={! this.state.canCreate}>{commit}</button>
           </div>
         </div>
       </div>

--- a/src/utils/ContentRepositoryUtil.js
+++ b/src/utils/ContentRepositoryUtil.js
@@ -52,7 +52,7 @@ function validateDirectory(dir, allOf, callback) {
     };
 
     async.reject(allOfPaths, isReadable, (missing) => {
-      let errors = missing.map((fpath) => `${path.basename(fpath)} isn't readable`);
+      let errors = missing.map((fpath) => `${path.basename(fpath)} can't be found.`);
 
       callback(null, errors || []);
     });
@@ -95,6 +95,7 @@ export function validateContentRepository({displayName, controlRepositoryLocatio
 
         if (results.length > 0) {
           results[0] = `This doesn't look like a ${preparer} repository: ${results[0]}`;
+          results.push("Try changing the preparer type or specifying a different path.");
         }
 
         cb(null, results);

--- a/src/utils/ContentRepositoryUtil.js
+++ b/src/utils/ContentRepositoryUtil.js
@@ -54,7 +54,7 @@ function validateDirectory(dir, allOf, callback) {
     async.reject(allOfPaths, isReadable, (missing) => {
       let errors = missing.map((fpath) => `${path.basename(fpath)} isn't readable`);
 
-      callback(null, errors);
+      callback(null, errors || []);
     });
   });
 }

--- a/styles/edit-content-repository.less
+++ b/styles/edit-content-repository.less
@@ -25,4 +25,16 @@
       margin-right: 5px;
     }
   }
+
+  .with-errors {
+    input {
+      border: solid 1px #f00;
+      background-color: #fee;
+    }
+
+    .validation-errors {
+      font-weight: bold;
+      color: #f00;
+    }
+  }
 }


### PR DESCRIPTION
Verify that the control and content repository directories exist, are readable, and look like valid control and content repositories. Show feedback on the "add a content repository" panel and disable the create button if inputs are invalid.

This is Part II of deconst/deconst-docs#155.
