### PR TITLE
Explicitly select a template for unmapped content.

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "deep-extend": "^0.4.0",
     "dockerode": "^2.1.4",
     "exec": "0.2.0",
+    "fs-walk": "0.0.1",
     "install": "^0.1.8",
     "jquery": "^2.1.3",
     "mixpanel": "kitematic/mixpanel-node",

--- a/src/actions/ContentRepositoryActions.js
+++ b/src/actions/ContentRepositoryActions.js
@@ -4,22 +4,22 @@ import ContentRepositoryUtil, {ContentRepository} from '../utils/ContentReposito
 
 class ContentRepositoryActions {
 
-  launch (id, displayName, controlRepositoryLocation, contentRepositoryPath, preparer) {
+  launch (id, displayName, controlRepositoryLocation, contentRepositoryPath, preparer, template) {
     let repo = new ContentRepository(
       id, displayName,
       controlRepositoryLocation, contentRepositoryPath,
-      preparer
+      preparer, template
     );
     this.dispatch({repo});
 
     ContentRepositoryUtil.launchServicePod(repo);
   }
 
-  edit (id, displayName, controlRepositoryLocation, contentRepositoryPath, preparer) {
+  edit (id, displayName, controlRepositoryLocation, contentRepositoryPath, preparer, template) {
     this.dispatch({
       id, displayName,
       controlRepositoryLocation, contentRepositoryPath,
-      preparer
+      preparer, template
     });
   }
 

--- a/src/browser.js
+++ b/src/browser.js
@@ -47,7 +47,7 @@ if (process.platform === 'win32') {
 app.on('ready', function () {
   var mainWindow = new BrowserWindow({
     width: size.width || 600,
-    height: size.height || 650,
+    height: size.height || 700,
     'min-width': os.platform() === 'win32' ? 400 : 600,
     'min-height': os.platform() === 'win32' ? 260 : 100,
     resizable: true,

--- a/src/components/EditContentRepository.react.js
+++ b/src/components/EditContentRepository.react.js
@@ -29,7 +29,7 @@ var EditContentRepository = React.createClass({
       controlRepositoryLocation: lastControlRepository,
       preparer: "sphinx",
       canCreate: false,
-      isMapped: true,
+      isMapped: false,
       template: null,
       templateOptions: [],
       validationErrors: {
@@ -244,20 +244,30 @@ var EditContentRepository = React.createClass({
       </div>
     ));
 
-    let templateSection;
-    if (! this.state.isMapped) {
-      templateSection = this.renderSection("template", "template", (
-        <div>
-          <h3>Template</h3>
-          <p className="explanation">Template to use while rendering this unmapped content.</p>
-          <select value={this.state.template} onChange={this.handleTemplateChange}>
-            {this.state.templateOptions.map((tpath) => {
-              return <option key={tpath} value={tpath}>{tpath}</option>;
-            })}
-          </select>
-        </div>
-      ));
-    };
+    let templateExplanation, templateDisable, templateOptions;
+    if (this.state.isMapped) {
+      templateExplanation = "Your content is mapped in the control repository, so no manual template selection is necessary.";
+      templateDisable = true;
+    } else if (this.state.templateOptions.length === 0) {
+      templateExplanation = "No templates to choose from, yet. Please specify both a control and content repository.";
+      templateDisable = true;
+    } else {
+      templateExplanation = "Template to use while rendering this unmapped content.";
+      templateDisable = false;
+      templateOptions = this.state.templateOptions.map((tpath) => {
+        return <option key={tpath} value={tpath}>{tpath}</option>;
+      });
+    }
+
+    let templateSection = this.renderSection("template", "template", (
+      <div>
+        <h3>Template</h3>
+        <p className="explanation">{templateExplanation}</p>
+        <select value={this.state.template} onChange={this.handleTemplateChange} disabled={templateDisable}>
+          {templateOptions}
+        </select>
+      </div>
+    ));
 
     return (
       <div className="edit-content-repository">

--- a/src/components/EditContentRepository.react.js
+++ b/src/components/EditContentRepository.react.js
@@ -2,6 +2,7 @@ import path from 'path';
 import React from 'react/addons';
 import Router from 'react-router';
 import remote from 'remote';
+import _ from 'underscore';
 
 var dialog = remote.require('dialog');
 
@@ -84,14 +85,31 @@ var EditContentRepository = React.createClass({
 
           this.setState({isMapped: results.isMapped});
 
-          availableTemplates(this.state.controlRepositoryLocation, results.site, (err, templateOptions) => {
-            if (err) {
-              console.error(err);
-              return;
-            }
+          if (!results.isMapped) {
+            availableTemplates(this.state.controlRepositoryLocation, results.site, (err, templateOptions) => {
+              if (err) {
+                console.error(err);
+                return;
+              }
 
-            this.setState({templateOptions});
-          });
+              let results = {templateOptions};
+              let needsReset = false;
+
+              if (this.state.template) {
+                needsReset = ! _.contains(templateOptions, this.state.template);
+              }
+
+              if (! this.state.template || needsReset) {
+                let choice = _.find(templateOptions, (each) => /default/.test(each))
+                if (choice === undefined && templateOptions.length > 0) {
+                  choice = templateOptions[0];
+                }
+                results.template = choice;
+              }
+
+              this.setState(results);
+            });
+          }
         });
       }
     });

--- a/src/components/EditContentRepository.react.js
+++ b/src/components/EditContentRepository.react.js
@@ -184,7 +184,8 @@ var EditContentRepository = React.createClass({
         displayName,
         this.state.controlRepositoryLocation,
         this.state.contentRepositoryPath,
-        this.state.preparer
+        this.state.preparer,
+        this.state.template
       );
     } else {
       ContentRepositoryActions.edit(
@@ -192,7 +193,8 @@ var EditContentRepository = React.createClass({
         displayName,
         this.state.controlRepositoryLocation,
         this.state.contentRepositoryPath,
-        this.state.preparer
+        this.state.preparer,
+        this.state.template
       );
     }
 

--- a/src/components/EditContentRepository.react.js
+++ b/src/components/EditContentRepository.react.js
@@ -5,7 +5,7 @@ import remote from 'remote';
 
 var dialog = remote.require('dialog');
 
-import {ContentRepository, validateContentRepository} from '../utils/ContentRepositoryUtil';
+import {ContentRepository, validateContentRepository, readMapsSync} from '../utils/ContentRepositoryUtil';
 import ContentRepositoryActions from '../actions/ContentRepositoryActions';
 import ContentRepositoryStore from '../stores/ContentRepositoryStore';
 
@@ -23,6 +23,9 @@ var EditContentRepository = React.createClass({
       controlRepositoryLocation: lastControlRepository,
       preparer: "sphinx",
       canCreate: false,
+      isMapped: true,
+      template: null,
+      templateOptions: [],
       validationErrors: {
         displayName: [],
         controlRepositoryLocation: [],
@@ -64,6 +67,24 @@ var EditContentRepository = React.createClass({
           this.state.controlRepositoryLocation !== null;
 
         this.setState({validationErrors: results, canCreate});
+      });
+
+      readMaps(this.state.contentRepositoryPath, this.state.controlRepositoryLocation, (err, results) => {
+        if (err) {
+          console.error(err);
+          return;
+        }
+
+        this.setState({isMapped: results.isMapped});
+      });
+
+      availableTemplates(this.state.controlRepositoryLocation, (err, templateOptions) => {
+        if (err) {
+          console.error(err);
+          return;
+        }
+
+        this.setState({templateOptions});
       });
     });
   },

--- a/src/components/EditContentRepository.react.js
+++ b/src/components/EditContentRepository.react.js
@@ -5,7 +5,7 @@ import remote from 'remote';
 
 var dialog = remote.require('dialog');
 
-import {ContentRepository, validateContentRepository, readMapsSync} from '../utils/ContentRepositoryUtil';
+import {ContentRepository, validateContentRepository, readMaps} from '../utils/ContentRepositoryUtil';
 import ContentRepositoryActions from '../actions/ContentRepositoryActions';
 import ContentRepositoryStore from '../stores/ContentRepositoryStore';
 
@@ -140,6 +140,10 @@ var EditContentRepository = React.createClass({
     this.revalidate({preparer: e.target.value});
   },
 
+  handleTemplateChange: function (e) {
+    this.revalidate({template: e.target.value});
+  },
+
   handleCancel: function () {
     this.transitionTo("repositoryList");
   },
@@ -212,6 +216,21 @@ var EditContentRepository = React.createClass({
       </div>
     ));
 
+    let templateSection;
+    if (! this.state.isMapped) {
+      templateSection = this.renderSection("template", "template", (
+        <div>
+          <h3>Template</h3>
+          <p className="explanation">Template to use while rendering this unmapped content.</p>
+          <select value={this.state.template} onChange={this.handleTemplateChange}>
+            {this.state.templateOptions.map((tpath) => {
+              <option key={tpath} value={tpath}>{tpath}</option>
+            })}
+          </select>
+        </div>
+      ));
+    };
+
     return (
       <div className="edit-content-repository">
         <div className="container">
@@ -220,6 +239,7 @@ var EditContentRepository = React.createClass({
           {repositoryPathSection}
           {controlRepositorySection}
           {preparerSection}
+          {templateSection}
           <div className="controls">
             <button className="btn btn-large btn-default" onClick={this.handleCancel}>Cancel</button>
             <button className="btn btn-large btn-primary" onClick={this.handleCommit} disabled={! this.state.canCreate}>{commit}</button>

--- a/src/stores/ContentRepositoryStore.js
+++ b/src/stores/ContentRepositoryStore.js
@@ -18,7 +18,7 @@ class ContentRepositoryStore {
     ContentRepositoryUtil.saveRepositories(this.repositories);
   }
 
-  onEdit({id, displayName, controlRepositoryLocation, contentRepositoryPath, preparer}) {
+  onEdit({id, displayName, controlRepositoryLocation, contentRepositoryPath, preparer, template}) {
     let r = this.repositories[id];
     if (!r) {
       return;
@@ -27,6 +27,7 @@ class ContentRepositoryStore {
     changed = changed || (controlRepositoryLocation !== r.controlRepositoryLocation);
     changed = changed || (contentRepositoryPath !== r.contentRepositoryPath);
     changed = changed || (preparer !== r.preparer);
+    changed = changed || (template !== r.template);
 
     if (!changed) {
       return;
@@ -36,6 +37,7 @@ class ContentRepositoryStore {
     r.controlRepositoryLocation = controlRepositoryLocation;
     r.contentRepositoryPath = contentRepositoryPath;
     r.preparer = preparer;
+    r.template = template;
 
     r.state = "relaunching";
 

--- a/src/utils/ContentRepositoryUtil.js
+++ b/src/utils/ContentRepositoryUtil.js
@@ -222,12 +222,13 @@ export function readMapsSync(contentRepositoryPath, controlRepositoryLocation) {
 
 export class ContentRepository {
 
-  constructor (id, displayName, controlRepositoryLocation, contentRepositoryPath, preparer) {
+  constructor (id, displayName, controlRepositoryLocation, contentRepositoryPath, preparer, template) {
     this.id = id || lastID++;
     this.displayName = displayName;
     this.controlRepositoryLocation = controlRepositoryLocation;
     this.contentRepositoryPath = contentRepositoryPath;
     this.preparer = preparer;
+    this.template = template;
 
     this.state = "launching";
     this.hasPrepared = false;
@@ -252,6 +253,11 @@ export class ContentRepository {
     this.prefix = result.prefix;
     this.templateRoutes = result.templateRoutes;
     this.isMapped = result.isMapped;
+
+    // Inject the template selection if necessary.
+    if (!this.isMapped && this.template) {
+      this.templateRoutes[`^${this.prefix}.*`] = this.template;
+    }
   }
 
   name () {

--- a/src/utils/ContentRepositoryUtil.js
+++ b/src/utils/ContentRepositoryUtil.js
@@ -4,6 +4,7 @@ import path from 'path';
 import util from 'util';
 import async from 'async';
 import mkdirp from 'mkdirp';
+import walk from 'fs-walk';
 import osenv from 'osenv';
 import urlJoin from 'url-join';
 import _ from 'underscore';
@@ -215,6 +216,27 @@ export class ContentRepository {
 
   contentURL() {
     return this._containerURL(this.contentContainer);
+  }
+
+  availableTemplates(callback) {
+    // End the root path with a / so the slice works properly.
+    let templateRoot = path.join(this.controlRepositoryLocation, "templates", this.site) + '/';
+    let templatePaths = [];
+
+    walk.files(templateRoot, (basedir, filename, stat, next) => {
+      let relativeDirPath = basedir.slice(templateRoot.length);
+
+      if (relativeDirPath.startsWith('_')) {
+        return next();
+      }
+
+      let templatePath = path.join(relativeDirPath, filename);
+      templatePaths.push(templatePath);
+    }, (err) => {
+      if (err) return callback(err);
+
+      callback(null, templatePaths);
+    });
   }
 
   canSubmit() {

--- a/src/utils/ContentRepositoryUtil.js
+++ b/src/utils/ContentRepositoryUtil.js
@@ -105,6 +105,27 @@ export function validateContentRepository({displayName, controlRepositoryLocatio
   }, callback);
 }
 
+export function availableTemplates (controlRepositoryLocation, callback) {
+  // End the root path with a / so the slice works properly.
+  let templateRoot = path.join(controlRepositoryLocation, "templates", this.site) + '/';
+  let templatePaths = [];
+
+  walk.files(templateRoot, (basedir, filename, stat, next) => {
+    let relativeDirPath = basedir.slice(templateRoot.length);
+
+    if (relativeDirPath.startsWith('_')) {
+      return next();
+    }
+
+    let templatePath = path.join(relativeDirPath, filename);
+    templatePaths.push(templatePath);
+  }, (err) => {
+    if (err) return callback(err);
+
+    callback(null, templatePaths);
+  });
+}
+
 export class ContentRepository {
 
   constructor (id, displayName, controlRepositoryLocation, contentRepositoryPath, preparer) {
@@ -219,27 +240,6 @@ export class ContentRepository {
 
   contentURL() {
     return this._containerURL(this.contentContainer);
-  }
-
-  availableTemplates(callback) {
-    // End the root path with a / so the slice works properly.
-    let templateRoot = path.join(this.controlRepositoryLocation, "templates", this.site) + '/';
-    let templatePaths = [];
-
-    walk.files(templateRoot, (basedir, filename, stat, next) => {
-      let relativeDirPath = basedir.slice(templateRoot.length);
-
-      if (relativeDirPath.startsWith('_')) {
-        return next();
-      }
-
-      let templatePath = path.join(relativeDirPath, filename);
-      templatePaths.push(templatePath);
-    }, (err) => {
-      if (err) return callback(err);
-
-      callback(null, templatePaths);
-    });
   }
 
   canSubmit() {

--- a/src/utils/ContentRepositoryUtil.js
+++ b/src/utils/ContentRepositoryUtil.js
@@ -160,15 +160,18 @@ export class ContentRepository {
         if (prefix !== undefined && ! this.site) {
           this.site = site;
           this.prefix = prefix;
+          this.isMapped = true;
         }
       });
 
       // Map to the first site in the conf file, if any are available, so that you at least have
       // a default template to render with.
       if (! this.site && sites.length > 0) {
+        this.isMapped = false;
         this.site = sites[0];
       }
     } catch (err) {
+      this.isMapped = false;
       console.error(err);
     }
 

--- a/styles/edit-content-repository.less
+++ b/styles/edit-content-repository.less
@@ -1,7 +1,12 @@
 .edit-content-repository {
   h3 {
+    font-size: 13pt;
     color: #888;
     border-bottom: solid 1px #888;
+  }
+
+  p.explanation {
+    font-style: italic;
   }
 
   input.line {
@@ -9,7 +14,7 @@
     width: 100%;
 
     &.fs-path {
-      width: 80%;
+      width: 85%;
     }
   }
 

--- a/styles/main.less
+++ b/styles/main.less
@@ -23,3 +23,8 @@ html, body {
 .container {
   padding: 10px 30px;
 }
+
+h1 {
+  font-size: 15pt;
+  text-align: center;
+}


### PR DESCRIPTION
If a content repository isn't mapped in the control repository, show an option to explicitly choose the template to render it with.

The final piece of deconst/deconst-docs#155.
