### PR TITLE
Don't mangle existing template routes.

### DIFF
--- a/src/utils/ContentRepositoryUtil.js
+++ b/src/utils/ContentRepositoryUtil.js
@@ -160,6 +160,11 @@ function interpretMaps(deconstConfig, contentMap, routesMap) {
     }
   }
 
+  // Ensure that the template route map contains, at least, the site that we're rendering.
+  if (! templateRoutes[site]) {
+    templateRoutes[site] = {routes: {}};
+  }
+
   return {contentIDBase, site, prefix, templateRoutes, isMapped};
 };
 
@@ -256,7 +261,8 @@ export class ContentRepository {
 
     // Inject the template selection if necessary.
     if (!this.isMapped && this.template) {
-      this.templateRoutes[`^${this.prefix}.*`] = this.template;
+      this.templateRoutes[this.site] = {routes: {}}
+      this.templateRoutes[this.site].routes[`^${this.prefix}.*`] = this.template;
     }
   }
 
@@ -382,9 +388,7 @@ export default {
     contentMap[repo.site].content[repo.prefix] = repo.contentIDBase;
     contentMap[repo.site].proxy["/__local_asset__/"] = "http://content:8080/assets/";
 
-    let templateRoutes = {};
-    templateRoutes[repo.site] = {};
-    templateRoutes[repo.site].routes = repo.templateRoutes;
+    let templateRoutes = repo.templateRoutes;
 
     let controlOverrideDir = path.join(osenv.home(), '.deconst', 'control-' + repo.id);
     let mapOverridePath = path.join(controlOverrideDir, 'content.json');


### PR DESCRIPTION
v3 seems to have broken the client's ability to render _already-mapped_ content in getting unmapped content to work. Basically, the control repository's routes.json file was being mangled during service pod launch:

```
$ jq . < ~/.deconst/control-0/routes.json 
{
  "developer.rackspace.com": {
    "routes": {
      "developer.rackspace.com": {
        "routes": {
          "^/": "default.html",
          "^/$": "index.html",
          "^/signup": "index.html",
          "^/databases": "databases-index.html",
          "^/blog": "blog-index.html",
          "^/blog/.+?": "blog-single.html",
          "^/blog/page?": "blog-index.html",
          "^/blog/categories": "blog-index.html",
          "^/blog/authors": "blog-index.html",
          "^/docs": "docs-home.html",
          "^/docs/.+?": "docs-page.html",
          "^/docs/user-guides/infrastructure/": "user-guide.html",
          "^/docs/cloud-images/v2/developer-guide": "docs-singlepage.html",
          "^/docs/cloud-load-balancers/v1/developer-guide": "docs-singlepage.html",
          "^/docs/rack-cli/": "rack-cli.html",
          "^/sdks": "sdks-home.html",
          "^/sdks/.+?": "sdks-page.html",
          "\\.xml$": "feed.xml"
        }
      }
    }
  }
}
```

This change handles the routes structure consistently and renders content with the correct template either way.

Fixes deconst/deconst-docs#170.
