### PR TITLE
Show template options when editing

### DIFF
--- a/src/components/EditContentRepository.react.js
+++ b/src/components/EditContentRepository.react.js
@@ -46,10 +46,12 @@ var EditContentRepository = React.createClass({
     if (id !== undefined) {
       let repo = ContentRepositoryStore.getState().repositories[id];
 
-      this.setState({
+      this.revalidate({
         isNew: false,
         manualDisplayName: !! repo.displayName,
         displayName: repo.name(),
+        template: repo.template,
+        templateOptions: [repo.template],
         contentRepositoryPath: repo.contentRepositoryPath,
         controlRepositoryLocation: repo.controlRepositoryLocation,
         preparer: repo.preparer


### PR DESCRIPTION
Editing an existing content repository wasn't performing an initial validation of the content, which is what's responsible for populating the template options drop-down. This performs a validation pass on first load of an existing repository.

Fixes deconst/deconst-docs#171.
